### PR TITLE
added per world config and blacklist worlds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# DeathGOD7 Files
+*.backup
+*.template
+
 # Compiled class file
 *.class
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Things that were added :
 - toggle switch for random respawn on death
 - fixed the config keys so it doesn't make plugin users confused
 - added per world config settings
+- added per world respawn world
 
-To Do List : 
-- remove debuggers in code
-- check for plugin error and bugs
+## Minor Bug
+You will respawn in the spawn point of Nether world if you are using the old version of Multiverse 4.2.2 and below and running a 1.16+ server.
+To fix that just use the latest build or v 4.3.0 or higher where multiverse fixed that issue.
 
 Code Updated by : https://github.com/DeathGOD7
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 
 Simple plugin to randomize any player spawn point. Suitable for Hardcore / Anarchy server.
 
+Things that were added : 
+- global values for world that don't have custom config
+- toggle switch for random respawn on death
+- fixed the config keys so it doesn't make plugin users confused
+- added per world config settings
+
+To Do List : 
+- remove debuggers in code
+- check for plugin error and bugs
+
+Code Updated by : https://github.com/DeathGOD7
+
+
 ## Commands and Permissions
 
 | Command                 | Description          | Permission          |
@@ -14,39 +27,68 @@ Simple plugin to randomize any player spawn point. Suitable for Hardcore / Anarc
 ## Configuration
 
 ```yaml
-# Set the coordinate to create rectangle area which
-# player will be randomly spawned at.
+# UnexpectedSpawn
+# Authors : Shivelight, DeathGOD7
+# Original : https://github.com/Shivelight/unexpectedspawn-paper
+# Modified : https://github.com/DeathGOD7/unexpectedspawn-paper
 
-# int : maximum x coordinate.
-x-max: 399
+global:
+  # Random respawn area for global settings.
+  x-max: 399
+  x-min: -399
+  z-max: 399
+  z-min: -399
 
-# int : minimum x coordinate.
-x-min: -399
+  # Do you want to have random respawn than normal world respawn? By default it is enabled in all worlds. If you want to
+  # disable it in specific world, then add that world name in below 'blacklisted-worlds'.
+  random-respawn:
+    # Do you want to have random respawn after user dies? If set to false then user will respawn in world spawnpoint.
+    # or bed/respawn anchor spawnpoint.
+    on-death: true
+    # Checks if bed respawn is taken priority. If set to false then it will force user to random respawn
+    # even if they have bed respawn point when they die.
+    bed-respawn-enabled: true
+    # Do you want to have random spawn when user joins for first time to prevent grief in spawn chunks? If set to false
+    # then user will spawn in default world spawnpoint.
+    on-first-join: false
+    # Enable this if you want to have random respawn each time user joins the server. It's best for Anarchy type server.
+    always-on-join: false
 
-# int : maximum z coordinate.
-z-max: 399
+  # Specify any block where you don't want user to be teleported. You don't them to drown in lava/water or land on
+  # someone else campfire, no?
+  spawn-block-blacklist:
+    - LAVA
+    - WATER
+    - CACTUS
+    - FIRE
+    - MAGMA_BLOCK
+    - SWEET_BERRY_BUSH
+    - CAMPFIRE
 
-# int : minimum x coordinate.
-z-min: -399
 
-# boolean : if this set to false, player will respawn
-# randomly even if they had a bed.
-bed-respawn-enabled: true
+# If no worlds are specified, it will use global/default variables. Default Config (worlds: [])
+# If you have added any world below, it will override the global settings.
+# If it got missing parameters that is in global settings like "spawn-block-blacklist"
+# but not in worlds world parameters then it will use global parameters.
+# All the features are same as global ones.
+# Please change "survival" to the name of your world and remove [] if you want to add worlds.
 
-# boolean : only randomize new player spawn.
-first-join-only: false
+worlds: []
+#  survival:
+#    x-max: 500
+#    x-min: -500
+#    z-max: 500
+#    z-min: -500
+#    random-respawn:
+#      on-death: true
+#      bed-respawn-enabled: true
+#      on-first-join: false
+#      always-on-join: false
 
-# boolean : randomize everytime player join.
-on-join: false
-
-# list of string : spawn block blaklist, player won't spawn
-# on blacklisted block.
-spawn-block-blacklist:
-  - LAVA
-  - WATER
-  - CACTUS
-  - FIRE
-  - MAGMA_BLOCK
-  - SWEET_BERRY_BUSH
-  - CAMPFIRE
+# If you have any worlds here , then it will be excluded from having random spawn
+# Even if you have set custom settings in above settings and you add that world to
+# blacklist, it will be excluded. Default :[]
+blacklisted-worlds:
+  - bedwars
+  - creative
 ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ global:
   z-max: 399
   z-min: -399
 
+  #Sets the global respawn world unless set in custom config worlds.
+  respawn-world: ''
+
   # Do you want to have random respawn than normal world respawn? By default it is enabled in all worlds. If you want to
   # disable it in specific world, then add that world name in below 'blacklisted-worlds'.
   random-respawn:
@@ -79,6 +82,7 @@ worlds: []
 #    x-min: -500
 #    z-max: 500
 #    z-min: -500
+#    respawn-world: ''
 #    random-respawn:
 #      on-death: true
 #      bed-respawn-enabled: true
@@ -88,9 +92,9 @@ worlds: []
 # If you have any worlds here , then it will be excluded from having random spawn
 # Even if you have set custom settings in above settings and you add that world to
 # blacklist, it will be excluded. Default :[]
-blacklisted-worlds:
-  - bedwars
-  - creative
+blacklisted-worlds: []
+#  - bedwars
+#  - creative
 ```
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -92,3 +92,8 @@ blacklisted-worlds:
   - bedwars
   - creative
 ```
+
+## Contributors
+- Shivelight
+- DeathGOD7
+- I dunno others name :D

--- a/README.md
+++ b/README.md
@@ -1,29 +1,36 @@
-![Artwork](assets/artwork.png)
+<p align="center">
+<img src="https://raw.githubusercontent.com/Shivelight/unexpectedspawn-paper/master/assets/artwork.png">
+<br>
+<img src="https://img.shields.io/badge/Crafted%20in-Java-red?style=flat&logo=java">
+<img src="https://img.shields.io/github/v/release/Shivelight/unexpectedspawn-paper?color=green">
+</p>
 
 **This is a [Paper](https://github.com/PaperMC/Paper) plugin!**
 
-Simple plugin to randomize any player spawn point. Suitable for Hardcore / Anarchy server.
+Simple plugin to randomize any player spawn point. Suitable for Hardcore / Anarchy server, or you just want people to be scattered in you server world.
 
 Things that were added : 
-- global values for world that don't have custom config
-- toggle switch for random respawn on death
-- fixed the config keys so it doesn't make plugin users confused
-- added per world config settings
-- added per world respawn world
+- Global values for world that don't have custom config
+- Toggle switch for random respawn on death
+- Fixed the config keys, so it doesn't make plugin users confused
+- Added per world config settings
+- Added per world respawn world
 
 ## Minor Bug
 You will respawn in the spawn point of Nether world if you are using the old version of Multiverse 4.2.2 and below and running a 1.16+ server.
 To fix that just use the latest build or v 4.3.0 or higher where multiverse fixed that issue.
+
+If you still have issues, please send it in Issues tab rather than sending it in spigot plugin page review.
 
 Code Updated by : https://github.com/DeathGOD7
 
 
 ## Commands and Permissions
 
-| Command                 | Description          | Permission          |
-| ----------------------- | -------------------- | ------------------- |
-| /unexpectedspawn        | Show version         | -                   |
-| /unexpectedspawn reload | Reload configuration | unexpectedspawn.use |
+| Command                 | Alias         | Description          | Permission          |
+| ----------------------- | ------------- | -------------------- | ------------------- |
+| /unexpectedspawn        |  /uns         | Shows version         | -                   |
+| /unexpectedspawn reload |  /uns reload  | Reload configuration | unexpectedspawn.use |
 
 ## Configuration
 
@@ -101,4 +108,4 @@ blacklisted-worlds: []
 ## Contributors
 - Shivelight
 - DeathGOD7
-- I dunno others name :D
+- Roshanxy

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>id.shivelight.paper</groupId>
     <artifactId>unexpectedspawn</artifactId>
-    <version>0.2.2</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
 
     <name>UnexpectedSpawn</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>id.shivelight.paper</groupId>
     <artifactId>unexpectedspawn</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>jar</packaging>
 
     <name>UnexpectedSpawn</name>

--- a/src/main/java/id/shivelight/paper/unexpectedspawn/LogConsole.java
+++ b/src/main/java/id/shivelight/paper/unexpectedspawn/LogConsole.java
@@ -1,0 +1,17 @@
+package id.shivelight.paper.unexpectedspawn;
+
+import org.bukkit.Bukkit;
+
+public class LogConsole {
+    static String logPrefix = "[UnexpectedSpawn] ";
+
+    public static void severe(String msg) {
+        Bukkit.getLogger().severe(logPrefix + msg);
+    }
+    public static void warn(String msg) {
+        Bukkit.getLogger().warning(logPrefix + msg);
+    }
+    public static void info(String msg) {
+        Bukkit.getLogger().info(logPrefix + msg);
+    }
+}

--- a/src/main/java/id/shivelight/paper/unexpectedspawn/Reload.java
+++ b/src/main/java/id/shivelight/paper/unexpectedspawn/Reload.java
@@ -38,6 +38,7 @@ public class Reload implements CommandExecutor {
             if (args.length == 1 && args[0].equalsIgnoreCase("reload")) {
                 if (sender.hasPermission("unexpectedspawn.use")) {
                     plugin.config.reloadConfig();
+                    //plugin.reloadConfig();
                     sender.sendMessage(Util.colorize("&8UnexpectedSpawn reloaded!"));
                     return true;
                 }
@@ -45,8 +46,8 @@ public class Reload implements CommandExecutor {
 
             String authors = String.join(", ", plugin.getDescription().getAuthors());
             String version = plugin.getDescription().getVersion();
-            sender.sendMessage(Util.colorize("UnexpectedSpawn &7version &8" + version));
-            sender.sendMessage(Util.colorize("Authors: &8" + authors + "&8&l ❤"));
+            sender.sendMessage(Util.colorize("UnexpectedSpawn Version : &8" + version));
+            sender.sendMessage(Util.colorize("Authors: &8" + authors));
 
             // By returning false, server will send out available commands.
             return !sender.hasPermission("unexpectedspawn.use");

--- a/src/main/java/id/shivelight/paper/unexpectedspawn/Spawn.java
+++ b/src/main/java/id/shivelight/paper/unexpectedspawn/Spawn.java
@@ -20,40 +20,19 @@
 
 package id.shivelight.paper.unexpectedspawn;
 
-import com.destroystokyo.paper.HeightmapType;
-import io.papermc.paper.world.MoonPhase;
-import org.apache.commons.lang.ObjectUtils;
-import org.bukkit.*;
-import org.bukkit.block.Biome;
-import org.bukkit.block.Block;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.boss.DragonBattle;
-import org.bukkit.entity.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.generator.BlockPopulator;
-import org.bukkit.generator.ChunkGenerator;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.MaterialData;
-import org.bukkit.metadata.MetadataValue;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.util.BoundingBox;
-import org.bukkit.util.Consumer;
-import org.bukkit.util.RayTraceResult;
-import org.bukkit.util.Vector;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Test;
 
-import java.io.File;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
+import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Predicate;
 
 public class Spawn implements Listener {
 

--- a/src/main/java/id/shivelight/paper/unexpectedspawn/Spawn.java
+++ b/src/main/java/id/shivelight/paper/unexpectedspawn/Spawn.java
@@ -37,29 +37,67 @@ public class Spawn implements Listener {
 
     private final UnexpectedSpawn plugin;
     private final HashSet<Material> blacklistedMaterial = new HashSet<>();
+    private final HashSet<World> blackListedWorlds = new HashSet<>();
 
     Spawn(UnexpectedSpawn plugin) {
         this.plugin = plugin;
-        List<String> materialList = plugin.config.getConfig().getStringList("spawn-block-blacklist");
-        for (String name : materialList) {
-            Material material = Material.getMaterial(name);
-            if (material == null) {
-                Bukkit.getLogger().warning("Material " + name + " is not valid. See https://papermc.io/javadocs/paper/org/bukkit/Material.html");
+
+//        List<String> materialList = plugin.config.getConfig().getStringList("global.spawn-block-blacklist");
+//        for (String name : materialList) {
+//            Material material = Material.getMaterial(name);
+//            if (material == null) {
+//                Bukkit.getLogger().warning("Material " + name + " is not valid. See https://papermc.io/javadocs/paper/org/bukkit/Material.html");
+//                continue;
+//            }
+//            blacklistedMaterial.add(material);
+//        }
+
+        List<String> worldList = plugin.config.getConfig().getStringList("blacklisted-worlds");
+        for (String name: worldList) {
+            World world = Bukkit.getWorld(name);
+            if (world == null) {
+                logMessageConsole("Couldn't find world "+ name + ". Either it doesn't exist or is not valid.","warn");
                 continue;
             }
-            blacklistedMaterial.add(material);
+            blackListedWorlds.add(world);
+        }
+    }
+
+    private void logMessageConsole(String msg, String type) {
+        String logPrefix = "[UnexpectedSpawn] ";
+        if (type.equals("severe")) {
+            Bukkit.getLogger().severe(logPrefix + msg);
+        }
+        else if (type.equals("warn")) {
+            Bukkit.getLogger().warning(logPrefix + msg);
+        }
+        else {
+            Bukkit.getLogger().info(logPrefix + msg);
         }
     }
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
         World joinWorld = event.getPlayer().getWorld();
+
         if (joinWorld.getEnvironment().equals(World.Environment.NETHER)
                 || joinWorld.getEnvironment().equals(World.Environment.THE_END)) {
             return;
         }
-        if ((!event.getPlayer().hasPlayedBefore() && plugin.config.getConfig().getBoolean("first-join-only"))
-                || plugin.config.getConfig().getBoolean("on-join")) {
+
+        if (blackListedWorlds.contains(joinWorld)) {
+            logMessageConsole("User in blacklisted world. So random join spawn is disabled.","info");
+            return;
+        }
+
+        String useCustomOnFirstJoin = checkWorldConfig(joinWorld, "random-respawn.on-first-join");
+        String useCustomAlwaysOnJoin = checkWorldConfig(joinWorld, "random-respawn.always-on-join");
+
+        logMessageConsole("Used config: " + useCustomOnFirstJoin + " for first join and the values is "+ plugin.config.getConfig().getBoolean(useCustomOnFirstJoin + "random-respawn.on-first-join"), "info");
+        logMessageConsole("Used config: " + useCustomAlwaysOnJoin + " for always on join and the values is "+ plugin.config.getConfig().getBoolean(useCustomAlwaysOnJoin + "random-respawn.always-on-join"), "info");
+
+        if ((!event.getPlayer().hasPlayedBefore() && plugin.config.getConfig().getBoolean(useCustomOnFirstJoin + "random-respawn.on-first-join"))
+                || plugin.config.getConfig().getBoolean(useCustomAlwaysOnJoin + "random-respawn.always-on-join")) {
             Location joinLocation = getRandomSpawnLocation(joinWorld);
             event.getPlayer().teleport(joinLocation);
         }
@@ -67,22 +105,76 @@ public class Spawn implements Listener {
 
     @EventHandler
     public void onRespawn(PlayerRespawnEvent event) {
+        // List<World> allWorlds = Bukkit.getWorlds();
+        World respawnWorld = event.getRespawnLocation().getWorld();
+
+        if (blackListedWorlds.contains(respawnWorld)) {
+            logMessageConsole("User in blacklisted world. So random respawn is disabled.","info");
+            return;
+        }
+
         if (ApiUtil.isAvailable(PlayerRespawnEvent.class, "isAnchorSpawn") && event.isAnchorSpawn()) {
             return;
         }
 
-        if (!event.isBedSpawn() || !plugin.config.getConfig().getBoolean("bed-respawn-enabled")) {
-            World respawnWorld = event.getRespawnLocation().getWorld();
-            Location respawnLocation = getRandomSpawnLocation(respawnWorld);
-            event.setRespawnLocation(respawnLocation);
+        String useCustomOnDeath = checkWorldConfig(respawnWorld, "random-respawn.on-death");
+        String useCustomBedRespawn = checkWorldConfig(respawnWorld, "random-respawn.bed-respawn-enabled");
+
+        logMessageConsole("Used config: " + useCustomOnDeath + " for on death and the values is "+ plugin.config.getConfig().getBoolean(useCustomOnDeath + "random-respawn.on-death"), "info");
+        logMessageConsole("Used config: " + useCustomBedRespawn + " for bed respawn and the values is "+ plugin.config.getConfig().getBoolean(useCustomBedRespawn + "random-respawn.bed-respawn-enabled"), "info");
+
+        if(plugin.config.getConfig().getBoolean(useCustomOnDeath + "random-respawn.on-death")) {
+            if (!event.isBedSpawn() || !plugin.config.getConfig().getBoolean(useCustomBedRespawn + "random-respawn.bed-respawn-enabled")) {
+                Location respawnLocation = getRandomSpawnLocation(respawnWorld);
+                event.setRespawnLocation(respawnLocation);
+            }
         }
     }
 
+
+    private String checkWorldConfig(World world, String config) {
+        List<String> worldList = plugin.config.getConfig().getStringList("worlds");
+        String worldName = world.getName();
+        if (plugin.config.getConfig().contains("worlds." + worldName + "." + config)) {
+            return ("worlds." + worldName + ".");
+        }
+        else {
+            return ("global.");
+        }
+    }
+
+    private HashSet<Material> getBlacklistedMaterials(String prefix) {
+        List<String> materialList = plugin.config.getConfig().getStringList(prefix + "spawn-block-blacklist");
+        blacklistedMaterial.clear();
+        for (String name : materialList) {
+            Material material = Material.getMaterial(name);
+            if (material == null) {
+                logMessageConsole("Material " + name + " is not valid. See https://papermc.io/javadocs/paper/org/bukkit/Material.html", "warn");
+                continue;
+            }
+            blacklistedMaterial.add(material);
+        }
+        return blacklistedMaterial;
+    }
+
     private Location getRandomSpawnLocation(World world) {
-        int xmin = plugin.config.getConfig().getInt("x-min");
-        int xmax = plugin.config.getConfig().getInt("x-max");
-        int zmin = plugin.config.getConfig().getInt("z-min");
-        int zmax = plugin.config.getConfig().getInt("z-max");
+        String useCustomMinX = checkWorldConfig(world, "x-min");
+        String useCustomMaxX = checkWorldConfig(world, "x-max");
+        String useCustomMinZ = checkWorldConfig(world, "z-min");
+        String useCustomMaxZ = checkWorldConfig(world, "z-max");
+
+        int xmin = plugin.config.getConfig().getInt(useCustomMinX + "x-min");
+        int xmax = plugin.config.getConfig().getInt(useCustomMaxX + "x-max");
+        int zmin = plugin.config.getConfig().getInt(useCustomMinZ + "z-min");
+        int zmax = plugin.config.getConfig().getInt(useCustomMaxZ + "z-max");
+
+        logMessageConsole("Used config: " + useCustomMinX + " for random respawn area and the values are ("+xmin+","+xmax+","+zmin+","+zmax+")","info");
+
+        String useCustomBlacklistedMaterials = checkWorldConfig(world, "spawn-block-blacklist");
+        HashSet<Material> blacklistedMaterials = getBlacklistedMaterials(useCustomBlacklistedMaterials);
+
+        logMessageConsole("Used config: " + useCustomBlacklistedMaterials + " and the values are : " + blacklistedMaterials,"info");
+
         while (true) {
             int x = xmin + ThreadLocalRandom.current().nextInt((xmax - xmin) + 1);
             int z = zmin + ThreadLocalRandom.current().nextInt((zmax - zmin) + 1);
@@ -96,7 +188,7 @@ public class Spawn implements Listener {
                 location = location.subtract(0, 1, 0);
             }
 
-            if (blacklistedMaterial.contains(location.getBlock().getType())) {
+            if (blacklistedMaterials.contains(location.getBlock().getType())) {
                 continue;
             }
 

--- a/src/main/java/id/shivelight/paper/unexpectedspawn/Spawn.java
+++ b/src/main/java/id/shivelight/paper/unexpectedspawn/Spawn.java
@@ -38,7 +38,7 @@ public class Spawn implements Listener {
 
     private final UnexpectedSpawn plugin;
     private final HashSet<Material> blacklistedMaterial = new HashSet<>();
-    private final HashSet<World> blackListedWorlds = new HashSet<>();
+    private final HashSet<World> blacklistedWorlds = new HashSet<>();
 
     Spawn(UnexpectedSpawn plugin) {
         this.plugin = plugin;
@@ -54,26 +54,13 @@ public class Spawn implements Listener {
 //        }
 
         List<String> worldList = plugin.config.getConfig().getStringList("blacklisted-worlds");
-        for (String name: worldList) {
+        for (String name : worldList) {
             World world = Bukkit.getWorld(name);
             if (world == null) {
-                logMessageConsole("Couldn't find world "+ name + ". Either it doesn't exist or is not valid.","warn");
+                LogConsole.warn("Couldn't find world " + name + ". Either it doesn't exist or is not valid.");
                 continue;
             }
-            blackListedWorlds.add(world);
-        }
-    }
-
-    private void logMessageConsole(String msg, String type) {
-        String logPrefix = "[UnexpectedSpawn] ";
-        if (type.equals("severe")) {
-            Bukkit.getLogger().severe(logPrefix + msg);
-        }
-        else if (type.equals("warn")) {
-            Bukkit.getLogger().warning(logPrefix + msg);
-        }
-        else {
-            Bukkit.getLogger().info(logPrefix + msg);
+            blacklistedWorlds.add(world);
         }
     }
 
@@ -93,9 +80,9 @@ public class Spawn implements Listener {
             return;
         }
 
-        if (blackListedWorlds.contains(joinWorld)) {
+        if (blacklistedWorlds.contains(joinWorld)) {
             // Debugger Start
-            //logMessageConsole("User in blacklisted world["+ joinWorld +"]. So random join spawn is disabled.","info");
+            //LogConsole.info("User in blacklisted world["+ joinWorld +"]. So random join spawn is disabled.");
             // Debugger End
             return;
         }
@@ -104,8 +91,8 @@ public class Spawn implements Listener {
         String useCustomAlwaysOnJoin = checkWorldConfig(joinWorld, "random-respawn.always-on-join");
 
         // Debugger Start
-        //logMessageConsole("Used config: " + useCustomOnFirstJoin + " for first join and the values is "+ plugin.config.getConfig().getBoolean(useCustomOnFirstJoin + "random-respawn.on-first-join"), "info");
-        //logMessageConsole("Used config: " + useCustomAlwaysOnJoin + " for always on join and the values is "+ plugin.config.getConfig().getBoolean(useCustomAlwaysOnJoin + "random-respawn.always-on-join"), "info");
+        //LogConsole.info("Used config: " + useCustomOnFirstJoin + " for first join and the values is "+ plugin.config.getConfig().getBoolean(useCustomOnFirstJoin + "random-respawn.on-first-join"));
+        //LogConsole.info("Used config: " + useCustomAlwaysOnJoin + " for always on join and the values is "+ plugin.config.getConfig().getBoolean(useCustomAlwaysOnJoin + "random-respawn.always-on-join"));
         // Debugger End
         
         if ((!event.getPlayer().hasPlayedBefore() && plugin.config.getConfig().getBoolean(useCustomOnFirstJoin + "random-respawn.on-first-join"))
@@ -126,31 +113,31 @@ public class Spawn implements Listener {
             if(obtainedData.isEmpty()){
                 respawnWorld = deathWorld;
                 String wName = respawnWorld.getName();
-                logMessageConsole("Using world ("+ wName +") where player died.","info");
+                LogConsole.info("Using world ("+ wName +") where player died.");
             }
             else {
                 World obtainedWorld = Bukkit.getWorld(obtainedData);
                 if (obtainedWorld == null) {
-                    logMessageConsole("Couldn't find world "+ obtainedData + ". Either it doesn't exist or is not valid.","warn");
+                    LogConsole.warn("Couldn't find world "+ obtainedData + ". Either it doesn't exist or is not valid.");
                     respawnWorld = deathWorld;;
                     String wName = respawnWorld.getName();
-                    logMessageConsole("Using world ("+ wName +") where player died.","info");
+                    LogConsole.info("Using world ("+ wName +") where player died.");
                 }
                 else {
                     respawnWorld = obtainedWorld;
 
                     String wName = respawnWorld.getName();
-                    logMessageConsole("Using world ("+ wName +") specified in config.","info");
+                    LogConsole.info("Using world ("+ wName +") specified in config.");
                 }
             }
         }
         else {
-            logMessageConsole("Respawn World in ("+useCustomWorld+") cannot be null. Please add empty string to disable it.","severe");
+            LogConsole.severe("Respawn World in ("+useCustomWorld+") cannot be null. Please add empty string to disable it.");
         }
 
-        if (blackListedWorlds.contains(respawnWorld)) {
+        if (blacklistedWorlds.contains(respawnWorld)) {
             // Debugger Start
-            //logMessageConsole("User in blacklisted world["+ respawnWorld +"]. So random respawn is disabled.","info");
+            //LogConsole.info("User in blacklisted world["+ respawnWorld +"]. So random respawn is disabled.","info");
             // Debugger End
             return;
         }
@@ -163,8 +150,8 @@ public class Spawn implements Listener {
         String useCustomBedRespawn = checkWorldConfig(respawnWorld, "random-respawn.bed-respawn-enabled");
 
         // Debugger Start
-        //logMessageConsole("Used config: " + useCustomOnDeath + " for on death and the values is "+ plugin.config.getConfig().getBoolean(useCustomOnDeath + "random-respawn.on-death"), "info");
-        //logMessageConsole("Used config: " + useCustomBedRespawn + " for bed respawn and the values is "+ plugin.config.getConfig().getBoolean(useCustomBedRespawn + "random-respawn.bed-respawn-enabled"), "info");
+        //LogConsole.info("Used config: " + useCustomOnDeath + " for on death and the values is "+ plugin.config.getConfig().getBoolean(useCustomOnDeath + "random-respawn.on-death"), "info");
+        //LogConsole.info("Used config: " + useCustomBedRespawn + " for bed respawn and the values is "+ plugin.config.getConfig().getBoolean(useCustomBedRespawn + "random-respawn.bed-respawn-enabled"), "info");
         // Debugger End
 
         if(plugin.config.getConfig().getBoolean(useCustomOnDeath + "random-respawn.on-death")) {
@@ -193,7 +180,7 @@ public class Spawn implements Listener {
         for (String name : materialList) {
             Material material = Material.getMaterial(name);
             if (material == null) {
-                logMessageConsole("Material " + name + " is not valid. See https://papermc.io/javadocs/paper/org/bukkit/Material.html", "warn");
+                LogConsole.warn("Material " + name + " is not valid. See https://papermc.io/javadocs/paper/org/bukkit/Material.html");
                 continue;
             }
             blacklistedMaterial.add(material);
@@ -213,14 +200,14 @@ public class Spawn implements Listener {
         int zmax = plugin.config.getConfig().getInt(useCustomMaxZ + "z-max");
 
         // Debugger Start
-        //logMessageConsole("Used config: " + useCustomMinX + " for random respawn area and the values are ("+xmin+","+xmax+","+zmin+","+zmax+")","info");
+        //LogConsole.info("Used config: " + useCustomMinX + " for random respawn area and the values are ("+xmin+","+xmax+","+zmin+","+zmax+")","info");
         // Debugger End
 
         String useCustomBlacklistedMaterials = checkWorldConfig(world, "spawn-block-blacklist");
-        HashSet<Material> blacklistedMaterials = getBlacklistedMaterials(useCustomBlacklistedMaterials);
+        HashSet<Material> worldBlacklistedMaterials = getBlacklistedMaterials(useCustomBlacklistedMaterials);
 
         // Debugger Start
-        //logMessageConsole("Used config: " + useCustomBlacklistedMaterials + " and the values are : " + blacklistedMaterials,"info");
+        //LogConsole.info("Used config: " + useCustomBlacklistedMaterials + " and the values are : " + blacklistedMaterials,"info");
         // Debugger End
 
         while (true) {
@@ -236,7 +223,7 @@ public class Spawn implements Listener {
                 location = location.subtract(0, 1, 0);
             }
 
-            if (blacklistedMaterials.contains(location.getBlock().getType())) {
+            if (worldBlacklistedMaterials.contains(location.getBlock().getType())) {
                 continue;
             }
 

--- a/src/main/java/id/shivelight/paper/unexpectedspawn/UnexpectedSpawn.java
+++ b/src/main/java/id/shivelight/paper/unexpectedspawn/UnexpectedSpawn.java
@@ -28,9 +28,11 @@ public final class UnexpectedSpawn extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        config = new ConfigAccessor(this, "config.yml");
-        config.getConfig().options().copyDefaults(true);
-        config.saveConfig();
+        this.config = new ConfigAccessor(this, "config.yml");
+        this.config.getConfig().options().copyDefaults(true);
+//        config.saveConfig();
+//        used this so the comment in config.yml is preserved.
+        this.config.saveDefaultConfig();
         getCommand("unexpectedspawn").setExecutor(new Reload(this));
         getServer().getPluginManager().registerEvents(new Spawn(this), this);
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,17 +1,64 @@
 # UnexpectedSpawn
-# https://github.com/Shivelight/unexpectedspawn-paper
-x-max: 399
-x-min: -399
-z-max: 399
-z-min: -399
-bed-respawn-enabled: true
-first-join-only: false
-on-join: false
-spawn-block-blacklist:
-  - LAVA
-  - WATER
-  - CACTUS
-  - FIRE
-  - MAGMA_BLOCK
-  - SWEET_BERRY_BUSH
-  - CAMPFIRE
+# Authors : Shivelight, DeathGOD7
+# Original : https://github.com/Shivelight/unexpectedspawn-paper
+# Modified : https://github.com/DeathGOD7/unexpectedspawn-paper
+
+global:
+  # Random respawn area for global settings.
+  x-max: 399
+  x-min: -399
+  z-max: 399
+  z-min: -399
+
+  # Do you want to have random respawn than normal world respawn? By default it is enabled in all worlds. If you want to
+  # disable it in specific world, then add that world name in below 'blacklisted-worlds'.
+  random-respawn:
+    # Do you want to have random respawn after user dies? If set to false then user will respawn in world spawnpoint.
+    # or bed/respawn anchor spawnpoint.
+    on-death: true
+    # Checks if bed respawn is taken priority. If set to false then it will force user to random respawn
+    # even if they have bed respawn point when they die.
+    bed-respawn-enabled: true
+    # Do you want to have random spawn when user joins for first time to prevent grief in spawn chunks? If set to false
+    # then user will spawn in default world spawnpoint.
+    on-first-join: false
+    # Enable this if you want to have random respawn each time user joins the server. It's best for Anarchy type server.
+    always-on-join: false
+
+  # Specify any block where you don't want user to be teleported. You don't them to drown in lava/water or land on
+  # someone else campfire, no?
+  spawn-block-blacklist:
+    - LAVA
+    - WATER
+    - CACTUS
+    - FIRE
+    - MAGMA_BLOCK
+    - SWEET_BERRY_BUSH
+    - CAMPFIRE
+
+
+# If no worlds are specified, it will use global/default variables. Default Config (worlds: [])
+# If you have added any world below, it will override the global settings.
+# If it got missing parameters that is in global settings like "spawn-block-blacklist"
+# but not in worlds world parameters then it will use global parameters.
+# All the features are same as global ones.
+# Please change "survival" to the name of your world and remove [] if you want to add worlds.
+
+worlds: []
+#  survival:
+#    x-max: 500
+#    x-min: -500
+#    z-max: 500
+#    z-min: -500
+#    random-respawn:
+#      on-death: true
+#      bed-respawn-enabled: true
+#      on-first-join: false
+#      always-on-join: false
+
+# If you have any worlds here , then it will be excluded from having random spawn
+# Even if you have set custom settings in above settings and you add that world to
+# blacklist, it will be excluded. Default :[]
+blacklisted-worlds:
+  - bedwars
+  - creative

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,9 @@ global:
   z-max: 399
   z-min: -399
 
+  #Sets the global respawn world unless set in custom config worlds.
+  respawn-world: ''
+
   # Do you want to have random respawn than normal world respawn? By default it is enabled in all worlds. If you want to
   # disable it in specific world, then add that world name in below 'blacklisted-worlds'.
   random-respawn:
@@ -50,6 +53,7 @@ worlds: []
 #    x-min: -500
 #    z-max: 500
 #    z-min: -500
+#    respawn-world: ''
 #    random-respawn:
 #      on-death: true
 #      bed-respawn-enabled: true
@@ -59,6 +63,6 @@ worlds: []
 # If you have any worlds here , then it will be excluded from having random spawn
 # Even if you have set custom settings in above settings and you add that world to
 # blacklist, it will be excluded. Default :[]
-blacklisted-worlds:
-  - bedwars
-  - creative
+blacklisted-worlds: []
+#  - bedwars
+#  - creative

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ authors: [Shivelight, DeathGOD7]
 description: Randomize player spawn point.
 prefix: UnexpectedSpawn
 website: https://shivelight.id
-softdepend: [MultiverseCore]
+softdepend: [Multiverse-Core]
 commands:
   unexpectedspawn:
     usage: /<command> reload

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,13 +2,16 @@ name: UnexpectedSpawn
 version: ${project.version}
 main: id.shivelight.paper.unexpectedspawn.UnexpectedSpawn
 api-version: 1.13
-authors: [Shivelight]
+authors: [Shivelight, DeathGOD7]
 description: Randomize player spawn point.
+prefix: UnexpectedSpawn
 website: https://shivelight.id
+softdepend: [MultiverseCore]
 commands:
   unexpectedspawn:
     usage: /<command> reload
     description: Reload UnexpectedSpawn.
+    aliases: uns
 permissions:
   unexpectedspawn.use:
     description: Use UnexpectedSpawn command.


### PR DESCRIPTION
Well as the name suggests I added some per world config and blacklist world that I was talking about in #6 .
It still needs debug logs to be removed and have some testing with other plugins like essential.

The test is done with build in my forked repo...with Multiverse Core
It works but if you have to SMP worlds in the same server..and have a bed respawn in world A and you die in world B...then you are randomly tped in the world A cause you have bed respawn there....and the respawn event takes the world you are going to spawn in.

To fix that you just need to disable bed respawns in multiverse worlds.yml for World B. But I haven't checked whether if it spawns you near bed...when having bed respawn in "world B" worlds.yml to false.