### PR TITLE
Update 0.3.1

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -44,13 +44,17 @@ If you still have issues, please send it in Issues tab rather than sending it in
 ## Additional Permissions
 
 - unexpectedspawn.use
-  (Allows user to do /uns reload) Default : OP
+(Allows user to do /uns reload)
+Default : OP
 
 - unexpectedspawn.notify
-  (Notifies user about their death location) Default : OP
+(Notifies user about their death location)
+Default : OP
 
 - unexpectedspawn.bypass
-  (Bypasses the random respawn or random join checks. Uses vanilla method) Default : OP
+(Bypasses the random respawn or random join checks. Uses vanilla method)
+Default : OP
+
 
 ## Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,16 @@
     </repositories>
 
     <dependencies>
+<!--        <dependency>-->
+<!--            <groupId>com.destroystokyo.paper</groupId>-->
+<!--            <artifactId>paper-api</artifactId>-->
+<!--            <version>1.16.5-R0.1-SNAPSHOT</version>-->
+<!--            <scope>provided</scope>-->
+<!--        </dependency>-->
         <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
+            <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>id.shivelight.paper</groupId>
     <artifactId>unexpectedspawn</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1-beta</version>
     <packaging>jar</packaging>
 
     <name>UnexpectedSpawn</name>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,7 +8,10 @@ global:
   z-max: 399
   z-min: -399
 
-  #Sets the global respawn world unless set in custom config worlds.
+  # Fail radius expansion if normal x and z area failed to obtain suitable block or location
+  fail-radius: 500
+
+  # Sets the global respawn world unless set in custom config worlds.
   respawn-world: 'world'
 
   # Do you want to have random respawn than normal world respawn? By default it is enabled in all worlds. If you want to
@@ -26,9 +29,11 @@ global:
     # Enable this if you want to have random respawn each time user joins the server. It's best for Anarchy type server.
     always-on-join: false
 
+  # Invert the blacklist to whitelist
+  invert-block-blacklist: false
+
   # Specify any block where you don't want user to be teleported. You don't them to drown in lava/water or land on
   # someone else campfire, no?
-  invert-block-blacklist: false
   spawn-block-blacklist:
     - LAVA
     - WATER
@@ -52,6 +57,7 @@ worlds: []
 #    x-min: -500
 #    z-max: 500
 #    z-min: -500
+#    fail-radius: 1000
 #    respawn-world: ''
 #    random-respawn:
 #      on-death: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,6 +28,7 @@ global:
 
   # Specify any block where you don't want user to be teleported. You don't them to drown in lava/water or land on
   # someone else campfire, no?
+  invert-block-blacklist: false
   spawn-block-blacklist:
     - LAVA
     - WATER


### PR DESCRIPTION
Added requested features and updated paper API plus fixed some minor bugs.

[New Config]
- added failure radius with customizable feature (currently limited the numbers of tries to 5000 minimum before it adds failure radius can be made customizable or increased or decreased or used internally)

[New Feature]
- added invert spawn blacklist (as requested by haha44444)
  ( also this may cause error if only 5-10 block are there in 400x400 area of spawn area and it will continue to look for that blocks infinite. so to fix that added failure radius and specified point where it will use the failure radius in search . and also added upper limit (10,000 tries) for random spawn searcher where player will be teleported to spawn point of world.)

[Bug Fix/Update]
- fixed/removed the adventure native chat formatter as it wasn't used much. Added ChatColor (legacy method. supposed to work in all Minecraft versions)

- updated paper API to 1.18.1 (1.18.1-R0.1-SNAPSHOT) to use all blocks of latest 1.17 and 1.18 update (so the group id is updated from com.destroystokyo.paper to io.papermc.paper )

- added more debugger to plugin so its easier to debug when error comes up.